### PR TITLE
refactor: streamline rust dependencies

### DIFF
--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.45"
+serde = { version = "*", features = ["derive"] }
+serde_json = "*"
+borsh = "*"
 near-sdk = "0.9.2"
-borsh = "0.6.1"
-wee_alloc = "0.4.5"
+wee_alloc = { version = "0.4.5", default-features = false, features = [] }
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
Partially satisfies https://github.com/near/devx/issues/157

Following the advice given [here] to ensure there are no different versions of common libraries

  [here]: https://github.com/near-examples/rust-status-message/pull/13#discussion_r416946300