### PR TITLE
Update .gitpod.yml to default to node

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,9 +22,9 @@ github:
 
 # List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
 tasks:
-  - before: nvm use default && npm install -g near-shell@0.23.2
+  - before: echo "nvm use default" >> ~/.bashrc && npm install -g near-shell@0.23.2 && nvm use default
     init: yarn && yarn build && yarn test:cargo
-    command: gp open README-Gitpod.md && yarn deploy:dev && source ./neardev/dev-account.env && yarn start:dev
+    command: source ~/.bashrc; gp open README-Gitpod.md && yarn deploy:dev && source ./neardev/dev-account.env && yarn start:dev
 
 ports:
   - port: 1234


### PR DESCRIPTION
This PR updates the `.gitpod.yml` file to set node as default. Prior to this, user would have to type nvm use default when opening new terminal windows in Gitpod.