### PR TITLE
FIx gitpod config

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -5,4 +5,4 @@ ENV CARGO_HOME=/home/gitpod/.cargo
 RUN bash -cl "rustup target add wasm32-unknown-unknown"
 
 RUN bash -c ". .nvm/nvm.sh \
-             && nvm install v12 && nvm alias default v12"
+             && nvm install v14 && nvm alias default v14"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,7 +22,7 @@ github:
 
 # List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
 tasks:
-  - before: echo "nvm use default" >> ~/.bashrc && npm install -g near-cli && nvm use default
+  - before: echo "nvm use 14.19.3" >> ~/.bashrc && npm install -g near-cli && nvm use default
     init: yarn
     command: source ~/.bashrc; gp open README-Gitpod.md && yarn dev
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,7 +22,7 @@ github:
 
 # List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
 tasks:
-  - before: echo "nvm use 14.19.3" >> ~/.bashrc && npm install -g near-cli && nvm use default
+  - before: echo "nvm use 14.19.3" >> ~/.bashrc && npm install -g near-cli && nvm use 14.19.3
     init: yarn
     command: source ~/.bashrc; gp open README-Gitpod.md && yarn dev
 


### PR DESCRIPTION
Fix gitpod config to use supported nodejs version.

Current error:
`error near-workspaces@2.0.0: The engine "node" is incompatible with this module. Expected version ">= 14.0.0". Got "12.22.7"`